### PR TITLE
Fix monitor

### DIFF
--- a/controller/monitor/funciones_monitor.php
+++ b/controller/monitor/funciones_monitor.php
@@ -5,7 +5,7 @@ function fill_pendientes($buscar)
 {
 	$sql = "SELECT id 
 				FROM ".$buscar." 
-			WHERE visto IS NULL OR resuelto IS NULL ";
+			WHERE visto IS NULL";
 
 	$result = query_num_rows($sql);
 

--- a/inicio.php
+++ b/inicio.php
@@ -2148,9 +2148,10 @@
 				{
 					document.getElementById("push").innerHTML="0";
 		  		}
+		  		setTimeout('push()',10000);
 			}
 
-			setInterval('push()',10000);
+			setTimeout('push()',10000);
 				
 		</script>
 	</body>


### PR DESCRIPTION
Cambia de "setInterval" a "setTimeout", ya que entraba en conflicto el javascript.

Edita la consulta SQL para que solo muestre notificación de que no ha sido abierta una solicitud.